### PR TITLE
effects: buffer repeat glitch

### DIFF
--- a/crates/modal-lib/src/compute/nodes/basic/delay.rs
+++ b/crates/modal-lib/src/compute/nodes/basic/delay.rs
@@ -36,9 +36,8 @@ impl Node for Delay {
         let input = data[0].as_float().unwrap_or(0.0);
         let feedback = feedback_gain * self.delay_impl.last_out();
 
-        let new_size = target_len;
-        if self.delay_impl.len() != new_size {
-            self.delay_impl.resize(new_size);
+        if self.delay_impl.len() != target_len {
+            self.delay_impl.resize(target_len);
         }
 
         self.delay_impl.push(input + feedback);

--- a/crates/modal-lib/src/compute/nodes/basic/delay/delay_impl.rs
+++ b/crates/modal-lib/src/compute/nodes/basic/delay/delay_impl.rs
@@ -206,6 +206,17 @@ impl RawDelay {
         self.last_out
     }
 
+    pub fn get(&self, sample: f32) -> f32 {
+        if sample.ceil() >= self.len() {
+            return self.last_out;
+        }
+
+        let low = self.data[sample.floor() as usize];
+        let high = self.data[sample.ceil() as usize];
+
+        low + (high - low) * sample.fract()
+    }
+
     pub fn clear(&mut self) {
         self.data.iter_mut().for_each(|s| *s = 0.0);
         self.last_out = 0.0;

--- a/crates/modal-lib/src/compute/nodes/effects/buffer_repeat.rs
+++ b/crates/modal-lib/src/compute/nodes/effects/buffer_repeat.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use runtime::{
+    node::{Input, Node, NodeEvent},
+    ExternInputs, Value, ValueKind,
+};
+
+use crate::compute::{
+    inputs::{
+        gate::{GateInput, GateInputState},
+        time::TimeInput,
+    },
+    nodes::all::delay::RawDelay,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BufferRepeat {
+    gate_in: Arc<GateInput>,
+    gate_state: GateInputState,
+    gate_prev: bool,
+    time_in: Arc<TimeInput>,
+    delay_impl: RawDelay,
+    cursor: f32,
+    out: f32,
+}
+
+impl BufferRepeat {
+    pub fn new(delay_impl: RawDelay) -> Self {
+        BufferRepeat {
+            gate_in: Arc::new(GateInput::new(0.5)),
+            gate_state: GateInputState::default(),
+            gate_prev: false,
+            time_in: Arc::new(TimeInput::new(delay_impl.len())),
+            delay_impl,
+            cursor: 0.0,
+            out: 0.0,
+        }
+    }
+}
+
+#[typetag::serde]
+impl Node for BufferRepeat {
+    fn feed(&mut self, _inputs: &ExternInputs, data: &[Value]) -> Vec<NodeEvent> {
+        let sig = data[0].as_float().unwrap_or_default();
+        let gate = self.gate_in.gate(&mut self.gate_state, &data[1]);
+        let target_len = self.time_in.get_samples(&data[2]);
+
+        let old_len = self.delay_impl.len();
+        if old_len != target_len {
+            self.delay_impl.resize(target_len);
+            self.cursor *= target_len / old_len;
+        }
+
+        if gate && !self.gate_prev {
+            self.cursor = 0.0;
+        }
+        self.gate_prev = gate;
+
+        if gate {
+            self.out = self.delay_impl.get(self.cursor);
+            self.cursor = (self.cursor + 1.0) % self.delay_impl.len();
+        } else {
+            self.delay_impl.push(sig);
+            self.out = sig;
+        }
+
+        Default::default()
+    }
+
+    fn read(&self, out: &mut [Value]) {
+        out[0] = Value::Float(self.out)
+    }
+
+    fn inputs(&self) -> Vec<Input> {
+        vec![
+            Input::new("sig", ValueKind::Float),
+            Input::stateful("gate", &self.gate_in),
+            Input::stateful("time", &self.time_in),
+        ]
+    }
+}
+
+pub fn buffer_repeat() -> Box<dyn Node> {
+    Box::new(BufferRepeat::new(RawDelay::new(4410)))
+}

--- a/crates/modal-lib/src/compute/nodes/effects/mod.rs
+++ b/crates/modal-lib/src/compute/nodes/effects/mod.rs
@@ -2,6 +2,7 @@ use super::NodeList;
 use runtime::node::Node;
 
 pub mod bits;
+pub mod buffer_repeat;
 pub mod chorus;
 pub mod clip;
 pub mod glide;
@@ -16,6 +17,11 @@ impl NodeList for Effects {
     fn all(&self) -> Vec<(Box<dyn Node>, String, Vec<String>)> {
         vec![
             (bits::bits(), "Bits".into(), vec!["Effect".into()]),
+            (
+                buffer_repeat::buffer_repeat(),
+                "Buffer Repeat".into(),
+                vec!["Effect".into()],
+            ),
             (chorus::chorus(), "Chorus".into(), vec!["Effect".into()]),
             (clip::clip(), "Clip".into(), vec!["Effect".into()]),
             (glide::glide(), "Glide".into(), vec!["Effect".into()]),


### PR DESCRIPTION
Repeats a recorded buffer continuously when enabled, otherwise passes the signal through with no delay.

Needed a fun detour from all those necessary features, UI/UX improvements and bug fixing…